### PR TITLE
Update LICENSE to avoid making pack use illegal.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@ LoneDev ItemsAdder Resource License
 Copyright (c) 2022 LoneDev
 
 Permissions:
-- You can use and edit this resource for your Minecraft servers if you own a license for ItemsAdder.
+- You can use and edit this resource for your Minecraft servers if you own a legitimate personal license for ItemsAdder.
 - You can use these assets in your server project if you own a legitimate personal license of ItemsAdder. You can let your players download the resourcepack in order to play the game but not for ANY other reasons.
 
 Limitations:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -16,3 +16,9 @@ Limitations:
 - You must include LoneDev in the credits of your project
 - You must share the edited assets without any restrictions to contribute to the development and enhancement of my project (example: you must share fixes if you find issues in this repo)
 - You must include this license file
+
+Warranty:
+- The package is without warranty of any kind, express or implied,
+including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement.
+In no event shall the authors or copyright holders be liable for any claim, damages or other liability,
+whether in an action of contract, tort or otherwise, arising from, out of or in connection with the assets or the use or other dealings in the assets.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,19 +3,20 @@ LoneDev ItemsAdder Resource License
 Copyright (c) 2022 LoneDev
 
 Permissions:
-- You can distributes theses assets if inside a zip file made by the ItemsAdder plugin only if you have a active and legitimate license of ItemsAdder for use for your Minecraft server if it contains and use ItemsAdder with a valid license
-- You can edit this source and use it in any free project you want
-- You can use your edited source in your Minecraft servers
+- You can use and edit this resource for your Minecraft servers if you own a license for ItemsAdder.
+- You can use these assets in your server project if you own a legitimate personal license of ItemsAdder. You can let your players download the resourcepack in order to play the game but not for ANY other reasons.
 
 Limitations:
-- You cannot distribute these assets or edited versions in commercial projects (example: reselling textures)
-- You cannot distribute these assets in projects not containing ItemsAdder with a valid license and that earn using advertisements or that take donations
-- You cannot use theses assets without a valid ItemsAdder license
-- You cannot sell or resell these assets or links to those assets
-- You cannot state that these are your assets
-- You must include LoneDev in the credits of your project
-- You must share the edited assets without any restrictions to contribute to the development and enhancement of my project (example: you must share fixes if you find issues in this repo)
-- You must include this license file
+- You cannot distribute these assets or edited versions of it in commercial projects (example: reselling textures) or projects that earn money from advertisement, subscriptions and other ways.
+- You cannot distribute these assets in projects not containing ItemsAdder with a valid license and that earn using advertisements or that take donations.
+- You cannot use theses assets without a valid ItemsAdder license.
+- You cannot sell or resell these assets or links to those assets.
+- You cannot share this repository files in any marketplace or website which is not Github. You must fork it directly using the Github feature in order to edit it.
+- You cannot state that these are your assets.
+- You must include LoneDev in the credits of your project.
+- You must share the edited assets without any restrictions to contribute to the development and enhancement of my project (example: you must share fixes if you find issues in this repo).
+- You can avoid sharing edited assets if they are pure edits for your specific server project (example: editing the color of a texture in order to make it more suitable for your server theme).
+- You must include this license file in your edited repository.
 
 Warranty:
 - The package is without warranty of any kind, express or implied,

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,18 +1,18 @@
-LoneDev super professional License
-
+LoneDev ItemsAdder Resource License
 
 Copyright (c) 2022 LoneDev
 
-
 Permissions:
+- You can distributes theses assets if inside a zip file made by the ItemsAdder plugin only if you have a active and legitimate license of ItemsAdder for use for your Minecraft server if it contains and use ItemsAdder with a valid license
 - You can edit this source and use it in any free project you want
 - You can use your edited source in your Minecraft servers
 
 Limitations:
-- You cannot use these assets or edited versions in commercial projects (example: reselling textures)
-- You cannot use these assets in projects that earn using advertisements or that take donations
-- You cannot resell these assets
+- You cannot distribute these assets or edited versions in commercial projects (example: reselling textures)
+- You cannot distribute these assets in projects not containing ItemsAdder with a valid license that earn using advertisements or that take donations
+- You cannot use theses assets without a valid ItemsAdder license
+- You cannot sell or resell these assets or links to those assets
 - You cannot state that these are your assets
 - You must include LoneDev in the credits of your project
-- You must share the edited assets to contribute to the development and enhancement of my project (example: you must share fixes if you find issues in this repo)
+- You must share the edited assets without any restrictions to contribute to the development and enhancement of my project (example: you must share fixes if you find issues in this repo)
 - You must include this license file

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,7 +9,7 @@ Permissions:
 
 Limitations:
 - You cannot distribute these assets or edited versions in commercial projects (example: reselling textures)
-- You cannot distribute these assets in projects not containing ItemsAdder with a valid license that earn using advertisements or that take donations
+- You cannot distribute these assets in projects not containing ItemsAdder with a valid license and that earn using advertisements or that take donations
 - You cannot use theses assets without a valid ItemsAdder license
 - You cannot sell or resell these assets or links to those assets
 - You cannot state that these are your assets


### PR DESCRIPTION
Should fix #7

The old license actually make illegal for Minecraft servers to uses theses assets too, this new license link the usage of theses assets to the validity of the ItemsAdder license, and make exception.

Also using this pack with ItemsAdder is currently illegal (both with old and new pack), as ItesmAdder doesn't put the license in the generated resource pack.

This file has a real legal value, so it's important it doesn't make this pack use illegal everywhere.

Fell free to modify/edit this license as much as you want, I tried to make it better, but I'm not a lawyer. 