### PR TITLE
Update wrong block name

### DIFF
--- a/contents/iasurvival/configs/crops/loots.yml
+++ b/contents/iasurvival/configs/crops/loots.yml
@@ -3,7 +3,7 @@ info:
 loots:
   blocks:
     grass:
-      type: GRASS
+      type: SHORT_GRASS
       items:
         tomato_seeds:
           item: iasurvival:tomato_seeds


### PR DESCRIPTION
The Item `GRASS` has been renamed to `SHORT_GRASS` in 1.20.4 iirc, causing the `/iazip` with the current default pack to fail:
![image](https://github.com/ItemsAdder/DefaultPack/assets/11576465/3e2c870d-b215-49cd-bfd3-60f1160fecfb)

This updates the item name to the proper one.